### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -37,7 +37,7 @@ jobs:
         prerelease: false
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: pypkgs/jupyter
         username: ${{ secrets.DOCKER_USERNAME_TB }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore